### PR TITLE
Accept 'host' as parameter

### DIFF
--- a/src/leap-system.js
+++ b/src/leap-system.js
@@ -6,6 +6,8 @@ var DEFAULT_SCALE = 0.001;
 var DEFAULT_POSITION = new THREE.Vector3();
 var DEFAULT_QUATERNION = new THREE.Quaternion();
 
+var DEFAULT_HOST = '127.0.0.1';
+
 Leap.Controller.plugin('transform', transform);
 
 /**
@@ -13,6 +15,7 @@ Leap.Controller.plugin('transform', transform);
  */
 export const System = AFRAME.registerSystem('leap', {
   schema: {
+    host: {default: DEFAULT_HOST},
     vr: {default: true},
     scale: {default: DEFAULT_SCALE},
     position: {
@@ -35,7 +38,8 @@ export const System = AFRAME.registerSystem('leap', {
   },
 
   init: function () {
-    this.controller = Leap.loop()
+    var {host} = this.data;
+    this.controller = Leap.loop({host})
       .use('transform', this.data);
   },
 


### PR DESCRIPTION
Allow passing `host` via system parameter, so the library can connect to remote hosts.

Example:
`<a-scene leap="host: 192.168.0.10">`